### PR TITLE
Hotfix: Configured CORS policy to allow GET API for our Backend; Entire user data is now stored in browser storage

### DIFF
--- a/client/src/actions/authenticationActions.js
+++ b/client/src/actions/authenticationActions.js
@@ -40,7 +40,7 @@ export const loginUser = async (userCredentials, setLoading, history) => {
 
     console.log(res.data);
 
-    localStorage.setItem("todotoken", res.data.token);
+    localStorage.setItem("todotoken", res.data);
 
     setLoading(false);
     history.push("/dashboard");

--- a/client/src/auth.js
+++ b/client/src/auth.js
@@ -1,6 +1,6 @@
 export const isLoggedIn = () => {
-  const token = localStorage.getItem("todotoken");
-  if (token) {
+  const user = localStorage.getItem("todotoken");
+  if (user && user.token) {
     return true;
   } else {
     return false;

--- a/server/src/main/java/com/theitcrowd/todo/WebSecurityConfiguration.java
+++ b/server/src/main/java/com/theitcrowd/todo/WebSecurityConfiguration.java
@@ -14,6 +14,8 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import com.theitcrowd.todo.auth.JWTRequestFilter;
 import com.theitcrowd.todo.auth.UserAuthDetailsService;
@@ -35,9 +37,19 @@ public class WebSecurityConfiguration extends WebSecurityConfigurerAdapter {
     @Override
     public void configure(HttpSecurity http) throws Exception {
         // CSRF support is disabled during development phase
-        http.csrf().disable().authorizeRequests().antMatchers("/api/user/*").permitAll().anyRequest().authenticated()
-                .and().sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
+        http.cors().and().csrf().disable().authorizeRequests().antMatchers("/api/user/*").permitAll().anyRequest()
+                .authenticated().and().sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
         http.addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
+    }
+
+    @Bean
+    public WebMvcConfigurer corsConfigurer() {
+        return new WebMvcConfigurer() {
+            @Override
+            public void addCorsMappings(CorsRegistry registry) {
+                registry.addMapping("/api/**").allowedOrigins("http://localhost:3000");
+            }
+        };
     }
 
     @Override


### PR DESCRIPTION
## The bug
CORS wasn't configured in our backend server so GET APIs weren't working.
The user's id wasn't being stored in local storage

## The fix
CORS is now configured to allow GET APIs from our backend. 
The user's entire data (id, email, username) as well as their JWT is now stored in the local storage.